### PR TITLE
Industry/Academia menu

### DIFF
--- a/src/components/sections/Section.astro
+++ b/src/components/sections/Section.astro
@@ -8,7 +8,9 @@ interface Props {
 const { id, title, classNames }: Props = Astro.props;
 ---
 
-<h2 id={id}>{title}</h2>
-<div class:list={["ui", classNames, "container"]}>
-    <slot />
+<div>
+    <h2 id={id}>{title}</h2>
+    <div class:list={["ui", classNames, "container"]}>
+        <slot />
+    </div>
 </div>

--- a/src/components/sections/SectionSelector.astro
+++ b/src/components/sections/SectionSelector.astro
@@ -1,0 +1,74 @@
+---
+interface Props {
+    sectionTitles: { name: string; id: string }[];
+}
+
+const { sectionTitles }: Props = Astro.props;
+---
+
+<div class="ui secondary pointing equal width menu">
+    {
+        sectionTitles.map((title) => {
+            return (
+                <a id={title.id} class="section-selector-item item">
+                    {title.name}
+                </a>
+            );
+        })
+    }
+</div>
+
+<script is:inline define:vars={{ sectionTitles }}>
+    // Get section selection
+    // If no section has been previously selected, default to the first section
+    const sectionSelection = (() => {
+        if (
+            typeof localStorage !== "undefined" &&
+            localStorage.getItem("sectionSelection")
+        ) {
+            return localStorage.getItem("sectionSelection");
+        }
+        // Default to the first section
+        return sectionTitles[0].id;
+    })();
+
+    // Set the section selection and display the corresponding section
+    const setSectionSelection = (sectionSelectionId, init = false) => {
+        document.getElementById(sectionSelectionId).classList.add("active");
+        window.localStorage.setItem("sectionSelection", sectionSelectionId);
+        // Only try to set the display if the section already exists (i.e. after initial render)
+        if (!init) {
+            document.getElementById(
+                `${sectionSelectionId}-section`
+            ).style.display = "block";
+        }
+    };
+
+    // Initialize the section selection
+    setSectionSelection(sectionSelection, (init = true));
+
+    const menuItems = document.querySelectorAll(".section-selector-item");
+    menuItems.forEach((item) => {
+        // Add click event listener to each menu item that sets the section
+        // selection, displays the corresponding section, and hides the others
+        item.addEventListener("click", () => {
+            menuItems.forEach((otherItem) => {
+                otherItem.classList.remove("active");
+                document.getElementById(
+                    `${otherItem.id}-section`
+                ).style.display = "none";
+            });
+            setSectionSelection(item.id);
+        });
+    });
+</script>
+
+<style>
+    .ui.menu {
+        background: var(--background-color) !important;
+    }
+
+    .item {
+        color: var(--text-color) !important;
+    }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,21 @@ import Contact from "../components/sections/Contact.astro";
 import Intro from "../components/sections/Intro.astro";
 import Papers from "../components/sections/Papers.astro";
 import Projects from "../components/sections/Projects.astro";
+import SectionSelector from "../components/sections/SectionSelector.astro";
 import Sidebar from "../components/sidebar/Sidebar.astro";
 import SidebarToggle from "../components/sidebar/SidebarToggle.astro";
 import PageWrapper from "../layouts/PageWrapper.astro";
+
+const sectionTitles = [
+    {
+        name: "Engineering",
+        id: "engineering",
+    },
+    {
+        name: "Academic",
+        id: "academic",
+    },
+];
 ---
 
 <PageWrapper
@@ -23,22 +35,47 @@ import PageWrapper from "../layouts/PageWrapper.astro";
         <Intro />
         <div class="ui divider"></div>
 
-        <!-- Experience -->
-        <!-- <Experience id="experience" />
-        <div class="ui divider"></div> -->
+        <SectionSelector sectionTitles={sectionTitles} />
 
-        <!-- Projects -->
-        <Projects id="projects" />
-        <div class="ui divider"></div>
+        <div id="engineering-section">
+            <!-- Experience -->
+            <!-- <Experience id="experience" />
+                <div class="ui divider"></div> -->
+            <!-- Projects -->
+            <Projects id="projects" />
+            <div class="ui divider"></div>
+        </div>
 
-        <!-- Papers -->
-        <Papers id="papers" />
-        <div class="ui divider"></div>
+        <div id="academic-section">
+            <!-- Papers -->
+            <Papers id="papers" />
+            <div class="ui divider"></div>
+        </div>
 
         <!-- Contact -->
         <Contact id="contact" />
     </main>
 </PageWrapper>
+
+<script is:inline define:vars={{ sectionTitles }}>
+    // Initial section display
+    // We want to show only the selected section on init, but we have to wait
+    // for the DOM to render them before we can hide them
+    //
+    // See primary logic for section selection in SectionSelector.astro script
+    const sectionSelection = localStorage.getItem("sectionSelection");
+    sectionTitles.forEach((sectionTitle) => {
+        if (sectionTitle.id === sectionSelection) {
+            document.getElementById(
+                `${sectionTitle.id}-section`
+            ).style.display = "block";
+        } else {
+            document.getElementById(
+                `${sectionTitle.id}-section`
+            ).style.display = "none";
+        }
+    });
+</script>
 
 <style>
     /* Fomantic overrides */


### PR DESCRIPTION
Closes #11 

- Adds [Fomantic UI pointing menu](https://fomantic-ui.com/collections/menu.html#pointing) to swap between engineering-related and academic-related details
- Section choice is stored in local storage for memory (similar to color preference)

