### PR TITLE
Dynamically hide sidebar toggle with screen size change

### DIFF
--- a/src/components/sidebar/Sidebar.astro
+++ b/src/components/sidebar/Sidebar.astro
@@ -151,9 +151,8 @@ import { resumeLink, cvLink } from "../constants.js";
         document.addEventListener("swiped-left", () => hideSidebar());
         document.addEventListener("swiped-right", () => showSidebar());
     } else {
-        // Always show sidebar on large screens and hide toggle arrow
+        // Always show sidebar on large screens
         sidebar.addClass("visible");
-        sidebarToggle.hidden = true;
     }
 </script>
 

--- a/src/components/sidebar/SidebarToggle.astro
+++ b/src/components/sidebar/SidebarToggle.astro
@@ -30,6 +30,11 @@
         animation-name: bounce;
         animation-duration: 2s;
         animation-iteration-count: infinite;
+
+        /* Hide toggle on large screens */
+        @media (min-width: 1160px) {
+            display: none;
+        }
     }
 
     #sidebar-toggle-hitbox {


### PR DESCRIPTION
Closes #24, using CSS for this makes sure that it changes visibility every time the user resizes the screen past the threshold